### PR TITLE
fix BUG Overlay.of(context)  return null

### DIFF
--- a/lib/achievement_view.dart
+++ b/lib/achievement_view.dart
@@ -17,11 +17,13 @@ class AchievementView {
   final String title;
   final String subTitle;
   final double elevation;
+  final OverlayState overlay;
 
   OverlayEntry _overlayEntry;
 
   AchievementView(
     this._context, {
+    this.overlay,
     this.elevation = 2,
     this.onTab,
     this.listener,
@@ -70,7 +72,7 @@ class AchievementView {
   void show() {
     if (_overlayEntry == null) {
       _overlayEntry = _buildOverlay();
-      Overlay.of(_context).insert(_overlayEntry);
+      (overlay ?? Overlay.of(_context)).insert(_overlayEntry);
     }
   }
 


### PR DESCRIPTION
Fix this bug
```dart
AchievementView(
    navigatorKey.currentState.context, // global navigator key
  // other options...
);
/* 
Throw NoSuchMethodError: The method 'insert' was called on null.
because Overlay.of(context)  return null
*/
``` 
with this option all is good
```dart
AchievementView(
    navigatorKey.currentState.context, // global navigator key
    overlay: navigatorKey.currentState.overlay,
  // other options...
);

```